### PR TITLE
Specify yarn version to 1.22.21 in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,10 @@ jobs:
      - image: cimg/node:12.13.1
     steps:
       - checkout
-      - run: yarn install
+      - node/install-yarn:
+        version: 1.22.21
+      - node/install-packages:
+          pkg-manager: yarn 
       - run: yarn coverage
 workflows:
   build-and-test:


### PR DESCRIPTION
The CI was using a docker image with a set version of yarn, we changed that to a specific version matching the README and the local development environment.
As discussed in #121.

----
Related to Evolved Binary internal tasks: [K-2719](https://evolvedbinaryltd.kanbanize.com/ctrl_board/16/cards/2719/details/), and [K-2721](https://evolvedbinaryltd.kanbanize.com/ctrl_board/16/cards/2721/details/)