### PR TITLE
Enable linting and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - checkout
       - run: yarn install
+      - run: yarn build
+      - run: yarn lint
       - run: yarn coverage
 workflows:
   build-and-test:


### PR DESCRIPTION
Adds linting in CI.
The Current CI rules do not run linting or compile the code.

----
Related to Evolved Binary internal task: [K-2721](https://evolvedbinaryltd.kanbanize.com/ctrl_board/16/cards/2721/details/)
