### PR TITLE
Bugfix correct the required Childtype check

### DIFF
--- a/packages/lwdita-xdita/test/utils.spec.ts
+++ b/packages/lwdita-xdita/test/utils.spec.ts
@@ -384,7 +384,7 @@ describe('isChildTypeSingle', () => {
 });
 
 describe('isChildTypeRequired', () => {
-  it('returns true for required childType object', () => {
+  it('returns true for required childType', () => {
     const childType = {
       name: 'child',
       single: false,
@@ -395,17 +395,19 @@ describe('isChildTypeRequired', () => {
     expect(result).to.be.true;
   });
 
-  //TODO: This test is failing cuz the function is not implemented correctly
-  // Related PR: https://github.com/evolvedbinary/jdita/pull/145
-  it.skip('returns true for string as required childtype', () => {
-    const child = 'child+';
+  it('returns true for string as required childtype', () => {
+    const child = 'child';
     const result = isChildTypeRequired(child);
     expect(result).to.be.true;
   });
 
-  //TODO: This test is failing cuz the function is not implemented correctly
-  // Related PR: https://github.com/evolvedbinary/jdita/pull/145
-  it.skip('returns true for required childtypes array', () => {
+  it('returns false for string as non-required childtype', () => {
+    const child = 'child?';
+    const result = isChildTypeRequired(child);
+    expect(result).to.be.false;
+  });
+
+  it('returns true for childtypes array', () => {
     const childType: ChildTypes = [
       {
         name: 'group1',

--- a/packages/lwdita-xdita/test/utils.spec.ts
+++ b/packages/lwdita-xdita/test/utils.spec.ts
@@ -407,7 +407,7 @@ describe('isChildTypeRequired', () => {
     expect(result).to.be.false;
   });
 
-  it('returns true for childtypes array', () => {
+  it('returns true for childtypes array with one required member', () => {
     const childType: ChildTypes = [
       {
         name: 'group1',
@@ -418,12 +418,57 @@ describe('isChildTypeRequired', () => {
       {
         name: 'group2',
         single: false,
+        required: false,
+        isGroup: false,
+      },
+    ];
+    const result = isChildTypeRequired(childType);
+    expect(result).to.be.true;
+  });
+
+  it('returns true for childtypes array with multiple required members', () => {
+    const childType: ChildTypes = [
+      {
+        name: 'group1',
+        single: false,
+        required: true,
+        isGroup: false,
+      },
+      {
+        name: 'group2',
+        single: false,
+        required: false,
+        isGroup: false,
+      },
+      {
+        name: 'group3',
+        single: false,
         required: true,
         isGroup: false,
       },
     ];
     const result = isChildTypeRequired(childType);
     expect(result).to.be.true;
+  });
+
+
+  it('returns false for childtypes array without required member', () => {
+    const childType: ChildTypes = [
+      {
+        name: 'group1',
+        single: false,
+        required: false,
+        isGroup: false,
+      },
+      {
+        name: 'group2',
+        single: false,
+        required: false,
+        isGroup: false,
+      },
+    ];
+    const result = isChildTypeRequired(childType);
+    expect(result).to.be.false;
   });
 
 });

--- a/packages/lwdita-xdita/utils.ts
+++ b/packages/lwdita-xdita/utils.ts
@@ -215,13 +215,8 @@ export function isChildTypeSingle(childType: string | ChildType | ChildTypes): b
 export function isChildTypeRequired(childType: string | ChildType | ChildTypes): boolean {
     // if it's an Array
     if (Array.isArray(childType)) {
-        let result = true;
         // if one of the children in the array is required then return true
-        childType.some(type => {
-            result = isChildTypeRequired(type);
-            return result;
-        });
-        return result;
+        return childType.some(isChildTypeRequired);
     } else {
         if (typeof childType === 'string') {
             // if it's a string parse it and check if it's required

--- a/packages/lwdita-xdita/utils.ts
+++ b/packages/lwdita-xdita/utils.ts
@@ -218,8 +218,8 @@ export function isChildTypeRequired(childType: string | ChildType | ChildTypes):
         let result = true;
         // if one of the children in the array is required then return true
         childType.some(type => {
-            result = !isChildTypeRequired(type);
-            return !result;
+            result = isChildTypeRequired(type);
+            return result;
         });
         return result;
     } else {


### PR DESCRIPTION
```js
let result = true;
// if one of the children in the array is required then return true
childType.some(type => {
    result = !isChildTypeRequired(type);
    return !result;
});
return result;
```
Within `isChildTypeRequired` we are checking if a `ChildType` is required or not, but when we are doing the check for the array we are returning the wrong value.

this happens by overriding the `result` variable by the wrong value.

This PR also provide tests for assure the correct value.
