### PR TITLE
Add tests for Node attributes

### DIFF
--- a/packages/lwdita-ast/test/alt.spec.ts
+++ b/packages/lwdita-ast/test/alt.spec.ts
@@ -1,24 +1,35 @@
 import { doNodeTest } from "../tests";
 import { AltNode, isAltNode } from "../nodes/alt";
+import { expect } from "chai";
 doNodeTest(AltNode, 'alt', isAltNode,
   ['outputclass', 'class', 'keyref', 'dir', 'xml:lang', 'translate', 'props'],
   ['(text|%ph|%data)*']);
 
-// TODO test the node attributes 
-// something like alt.outputclass reading and writing, making sure the attribute exists on the node and can be 
-// manipulated
 
-
-// eg of wrong case
-// setting alt.attributes does not throw any error
-// if the class does not have the correct attributes it does not throw
 
 describe('AltNode attributes', () => {
   it("can set correct attributes", () => {
-    //TODO
-  });
-  
-  it("can not set incorrect attributes",() => {
-    //TODO
+    // create a new node without setting anything. 
+    const alt = new AltNode({});
+    //go over all the attributes and set them
+    // see if we can get all of the attributes back again
+    // `keyref`, `outputclass`, `class`, `dir`, `xml:lang`, `translate`, `props`
+
+    alt.keyref = "keyref";
+    alt.outputclass = "outputclass";
+    alt.class = "class";
+    alt.dir = "dir";
+    alt["xml:lang"] = "lang";
+    alt.translate = "translate";
+    alt.props = "props";
+
+    expect(alt.keyref).to.equal("keyref");
+    expect(alt.outputclass).to.equal("outputclass");
+    expect(alt.class).to.equal("class");
+    expect(alt.dir).to.equal("dir");
+    expect(alt["xml:lang"]).to.equal("lang");
+    expect(alt.translate).to.equal("translate");
+    expect(alt.props).to.equal("props");
+    
   });
 });

--- a/packages/lwdita-ast/test/alt.spec.ts
+++ b/packages/lwdita-ast/test/alt.spec.ts
@@ -3,3 +3,22 @@ import { AltNode, isAltNode } from "../nodes/alt";
 doNodeTest(AltNode, 'alt', isAltNode,
   ['outputclass', 'class', 'keyref', 'dir', 'xml:lang', 'translate', 'props'],
   ['(text|%ph|%data)*']);
+
+// TODO test the node attributes 
+// something like alt.outputclass reading and writing, making sure the attribute exists on the node and can be 
+// manipulated
+
+
+// eg of wrong case
+// setting alt.attributes does not throw any error
+// if the class does not have the correct attributes it does not throw
+
+describe('AltNode attributes', () => {
+  it("can set correct attributes", () => {
+    //TODO
+  });
+  
+  it("can not set incorrect attributes",() => {
+    //TODO
+  });
+});

--- a/packages/lwdita-ast/test/alt.spec.ts
+++ b/packages/lwdita-ast/test/alt.spec.ts
@@ -1,19 +1,14 @@
 import { doNodeTest } from "../tests";
 import { AltNode, isAltNode } from "../nodes/alt";
 import { expect } from "chai";
+
 doNodeTest(AltNode, 'alt', isAltNode,
   ['outputclass', 'class', 'keyref', 'dir', 'xml:lang', 'translate', 'props'],
   ['(text|%ph|%data)*']);
 
-
-
-describe('AltNode attributes', () => {
-  it("can set correct attributes", () => {
-    // create a new node without setting anything. 
+describe('Class AltNode', () => {
+  it("sets correct attributes", () => {
     const alt = new AltNode({});
-    //go over all the attributes and set them
-    // see if we can get all of the attributes back again
-    // `keyref`, `outputclass`, `class`, `dir`, `xml:lang`, `translate`, `props`
 
     alt.keyref = "keyref";
     alt.outputclass = "outputclass";
@@ -30,6 +25,5 @@ describe('AltNode attributes', () => {
     expect(alt["xml:lang"]).to.equal("lang");
     expect(alt.translate).to.equal("translate");
     expect(alt.props).to.equal("props");
-    
   });
 });

--- a/packages/lwdita-ast/test/body.spec.ts
+++ b/packages/lwdita-ast/test/body.spec.ts
@@ -1,18 +1,14 @@
 import { doNodeTest } from "../tests";
 import { BodyNode, isBodyNode } from "../nodes/body";
 import { expect } from "chai";
+
 doNodeTest(BodyNode, 'body', isBodyNode,
   ['dir', 'xml:lang', 'translate', 'outputclass', 'class'],
   ['%list-blocks*', 'section*', 'fn*']);
 
-
-
-describe('Body Node attributes', () => {
-  it("can set correct attributes", () => {
-    // create a new node without setting anything. 
+describe('Class Node', () => {
+  it("sets correct attributes", () => {
     const body = new BodyNode({});
-
-    // 'dir', 'xml:lang', 'translate', 'outputclass', 'class'
 
     body.dir = "dir";
     body["xml:lang"] = "lang";
@@ -25,6 +21,5 @@ describe('Body Node attributes', () => {
     expect(body.translate).to.equal("translate");
     expect(body.outputclass).to.equal("outputclass");
     expect(body.class).to.equal("class");
-
   });
 });

--- a/packages/lwdita-ast/test/body.spec.ts
+++ b/packages/lwdita-ast/test/body.spec.ts
@@ -6,7 +6,7 @@ doNodeTest(BodyNode, 'body', isBodyNode,
   ['dir', 'xml:lang', 'translate', 'outputclass', 'class'],
   ['%list-blocks*', 'section*', 'fn*']);
 
-describe('Class Node', () => {
+describe('Class BodyNode', () => {
   it("sets correct attributes", () => {
     const body = new BodyNode({});
 

--- a/packages/lwdita-ast/test/body.spec.ts
+++ b/packages/lwdita-ast/test/body.spec.ts
@@ -1,5 +1,30 @@
 import { doNodeTest } from "../tests";
 import { BodyNode, isBodyNode } from "../nodes/body";
+import { expect } from "chai";
 doNodeTest(BodyNode, 'body', isBodyNode,
   ['dir', 'xml:lang', 'translate', 'outputclass', 'class'],
   ['%list-blocks*', 'section*', 'fn*']);
+
+
+
+describe('Body Node attributes', () => {
+  it("can set correct attributes", () => {
+    // create a new node without setting anything. 
+    const body = new BodyNode({});
+
+    // 'dir', 'xml:lang', 'translate', 'outputclass', 'class'
+
+    body.dir = "dir";
+    body["xml:lang"] = "lang";
+    body.translate = "translate";
+    body.outputclass = "outputclass";
+    body.class = "class";
+
+    expect(body.dir).to.equal("dir");
+    expect(body["xml:lang"]).to.equal("lang");
+    expect(body.translate).to.equal("translate");
+    expect(body.outputclass).to.equal("outputclass");
+    expect(body.class).to.equal("class");
+
+  });
+});

--- a/packages/lwdita-ast/test/p.spec.ts
+++ b/packages/lwdita-ast/test/p.spec.ts
@@ -1,18 +1,14 @@
 import { doNodeTest } from "../tests";
 import { PNode, isPNode } from "../nodes/p";
 import { expect } from "chai";
+
 doNodeTest(PNode, 'p', isPNode,
   ['dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'],
   ['%all-inline*']);
 
-
-
-describe('P Node attributes', () => {
-  it("can set correct attributes", () => {
-    // create a new node without setting anything. 
+describe('Class PNode', () => {
+  it("sets correct attributes", () => {
     const p = new PNode({});
-
-    // 'dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'
 
     p.dir = "dir";
     p["xml:lang"] = "lang";
@@ -29,6 +25,5 @@ describe('P Node attributes', () => {
     expect(p.id).to.equal("id");
     expect(p.outputclass).to.equal("outputclass");
     expect(p.class).to.equal("class");
-
   });
 });

--- a/packages/lwdita-ast/test/p.spec.ts
+++ b/packages/lwdita-ast/test/p.spec.ts
@@ -1,5 +1,34 @@
 import { doNodeTest } from "../tests";
 import { PNode, isPNode } from "../nodes/p";
+import { expect } from "chai";
 doNodeTest(PNode, 'p', isPNode,
   ['dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'],
   ['%all-inline*']);
+
+
+
+describe('P Node attributes', () => {
+  it("can set correct attributes", () => {
+    // create a new node without setting anything. 
+    const p = new PNode({});
+
+    // 'dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'
+
+    p.dir = "dir";
+    p["xml:lang"] = "lang";
+    p.translate = "translate";
+    p.props = "props";
+    p.id = "id";
+    p.outputclass = "outputclass";
+    p.class = "class";
+
+    expect(p.dir).to.equal("dir");
+    expect(p["xml:lang"]).to.equal("lang");
+    expect(p.translate).to.equal("translate");
+    expect(p.props).to.equal("props");
+    expect(p.id).to.equal("id");
+    expect(p.outputclass).to.equal("outputclass");
+    expect(p.class).to.equal("class");
+
+  });
+});

--- a/packages/lwdita-ast/test/section.spec.ts
+++ b/packages/lwdita-ast/test/section.spec.ts
@@ -1,5 +1,35 @@
 import { doNodeTest } from "../tests";
 import { SectionNode, isSectionNode } from "../nodes/section";
+import { expect } from "chai";
 doNodeTest(SectionNode, 'section', isSectionNode,
   ['dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'],
   ['title?', '%all-blocks*']);
+
+
+describe('Body Node attributes', () => {
+  it("can set correct attributes", () => {
+    // create a new node without setting anything. 
+    const section = new SectionNode({});
+
+    // 'dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'
+
+    section.dir = "dir";
+    section["xml:lang"] = "lang";
+    section.translate = "translate";
+    section.props = "props";
+    section.id = "id";
+    section.conref = "conref";
+    section.outputclass = "outputclass";
+    section.class = "class";
+
+    expect(section.dir).to.equal("dir");
+    expect(section["xml:lang"]).to.equal("lang");
+    expect(section.translate).to.equal("translate");
+    expect(section.props).to.equal("props");
+    expect(section.id).to.equal("id");
+    expect(section.conref).to.equal("conref");
+    expect(section.outputclass).to.equal("outputclass");
+    expect(section.class).to.equal("class");
+
+  });
+});

--- a/packages/lwdita-ast/test/section.spec.ts
+++ b/packages/lwdita-ast/test/section.spec.ts
@@ -1,18 +1,15 @@
 import { doNodeTest } from "../tests";
 import { SectionNode, isSectionNode } from "../nodes/section";
 import { expect } from "chai";
+
 doNodeTest(SectionNode, 'section', isSectionNode,
   ['dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'],
   ['title?', '%all-blocks*']);
 
-
-describe('Body Node attributes', () => {
-  it("can set correct attributes", () => {
-    // create a new node without setting anything. 
+describe('Class SectionNode', () => {
+  it("sets correct attributes", () => {
     const section = new SectionNode({});
-
-    // 'dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'
-
+    
     section.dir = "dir";
     section["xml:lang"] = "lang";
     section.translate = "translate";
@@ -30,6 +27,5 @@ describe('Body Node attributes', () => {
     expect(section.conref).to.equal("conref");
     expect(section.outputclass).to.equal("outputclass");
     expect(section.class).to.equal("class");
-
   });
 });

--- a/packages/lwdita-ast/test/title.spec.ts
+++ b/packages/lwdita-ast/test/title.spec.ts
@@ -1,5 +1,29 @@
 import { doNodeTest } from "../tests";
 import { TitleNode, isTitleNode } from "../nodes/title";
+import { expect } from "chai";
 doNodeTest(TitleNode, 'title', isTitleNode,
   ['dir', 'xml:lang', 'translate', 'outputclass', 'class'],
   ['%common-inline*']);
+
+
+  describe('Body Node attributes', () => {
+    it("can set correct attributes", () => {
+      // create a new node without setting anything. 
+      const title = new TitleNode({});
+  
+      // 'dir', 'xml:lang', 'translate', 'outputclass', 'class'
+  
+      title.dir = "dir";
+      title["xml:lang"] = "lang";
+      title.translate = "translate";
+      title.outputclass = "outputclass";
+      title.class = "class";
+  
+      expect(title.dir).to.equal("dir");
+      expect(title["xml:lang"]).to.equal("lang");
+      expect(title.translate).to.equal("translate");
+      expect(title.outputclass).to.equal("outputclass");
+      expect(title.class).to.equal("class");
+  
+    });
+  });

--- a/packages/lwdita-ast/test/title.spec.ts
+++ b/packages/lwdita-ast/test/title.spec.ts
@@ -1,29 +1,25 @@
 import { doNodeTest } from "../tests";
 import { TitleNode, isTitleNode } from "../nodes/title";
 import { expect } from "chai";
+
 doNodeTest(TitleNode, 'title', isTitleNode,
   ['dir', 'xml:lang', 'translate', 'outputclass', 'class'],
   ['%common-inline*']);
 
+describe('Class TitleNode', () => {
+  it("sets correct attributes", () => {
+    const title = new TitleNode({});
 
-  describe('Body Node attributes', () => {
-    it("can set correct attributes", () => {
-      // create a new node without setting anything. 
-      const title = new TitleNode({});
-  
-      // 'dir', 'xml:lang', 'translate', 'outputclass', 'class'
-  
-      title.dir = "dir";
-      title["xml:lang"] = "lang";
-      title.translate = "translate";
-      title.outputclass = "outputclass";
-      title.class = "class";
-  
-      expect(title.dir).to.equal("dir");
-      expect(title["xml:lang"]).to.equal("lang");
-      expect(title.translate).to.equal("translate");
-      expect(title.outputclass).to.equal("outputclass");
-      expect(title.class).to.equal("class");
-  
-    });
+    title.dir = "dir";
+    title["xml:lang"] = "lang";
+    title.translate = "translate";
+    title.outputclass = "outputclass";
+    title.class = "class";
+
+    expect(title.dir).to.equal("dir");
+    expect(title["xml:lang"]).to.equal("lang");
+    expect(title.translate).to.equal("translate");
+    expect(title.outputclass).to.equal("outputclass");
+    expect(title.class).to.equal("class");
   });
+});

--- a/packages/lwdita-ast/test/topic.spec.ts
+++ b/packages/lwdita-ast/test/topic.spec.ts
@@ -1,5 +1,32 @@
 import { doNodeTest } from "../tests";
 import { TopicNode, isTopicNode } from "../nodes/topic";
+import { expect } from "chai";
+
 doNodeTest(TopicNode, 'topic', isTopicNode,
   ['xmlns:ditaarch', 'ditaarch:DITAArchVersion', 'outputclass', 'class', 'dir', 'xml:lang', 'translate', 'domains', 'id'],
   ['title', 'shortdesc?', 'prolog?', 'body?']);
+
+describe.only('Class TopicNode', () => {
+  it("sets correct attributes", () => {
+    const topic = new TopicNode({});
+    topic.dir = "dir";
+    topic["xml:lang"] = "lang";
+    topic.translate = "translate";
+    topic.class = "class";
+    topic.outputclass = "outputclass";
+    topic.id = "id";
+    topic["xmlns:ditaarch"] = "xmlns:ditaarch";
+    topic["ditaarch:DITAArchVersion"] = "ditaarch:DITAArchVersion";
+    topic.domains = "domains";
+
+    expect(topic.dir).to.equal("dir");
+    expect(topic["xml:lang"]).to.equal("lang");
+    expect(topic.translate).to.equal("translate");
+    expect(topic.class).to.equal("class");
+    expect(topic.outputclass).to.equal("outputclass");
+    expect(topic.id).to.equal("id");
+    expect(topic["xmlns:ditaarch"]).to.equal("xmlns:ditaarch");
+    expect(topic["ditaarch:DITAArchVersion"]).to.equal("ditaarch:DITAArchVersion");
+    expect(topic.domains).to.equal("domains");
+  });
+});

--- a/packages/lwdita-ast/test/topic.spec.ts
+++ b/packages/lwdita-ast/test/topic.spec.ts
@@ -9,6 +9,7 @@ doNodeTest(TopicNode, 'topic', isTopicNode,
 describe('Class TopicNode', () => {
   it("sets correct attributes", () => {
     const topic = new TopicNode({});
+    
     topic.dir = "dir";
     topic["xml:lang"] = "lang";
     topic.translate = "translate";

--- a/packages/lwdita-ast/test/topic.spec.ts
+++ b/packages/lwdita-ast/test/topic.spec.ts
@@ -6,7 +6,7 @@ doNodeTest(TopicNode, 'topic', isTopicNode,
   ['xmlns:ditaarch', 'ditaarch:DITAArchVersion', 'outputclass', 'class', 'dir', 'xml:lang', 'translate', 'domains', 'id'],
   ['title', 'shortdesc?', 'prolog?', 'body?']);
 
-describe.only('Class TopicNode', () => {
+describe('Class TopicNode', () => {
   it("sets correct attributes", () => {
     const topic = new TopicNode({});
     topic.dir = "dir";


### PR DESCRIPTION
Test setting and getting known Node attributes for some common node like: `p` `alt` `topic` `section`

**How to test the PR**
```shell
yarn run test
```