### PR TITLE
Rename converter functions to better clarify the meaning

### DIFF
--- a/packages/lwdita-xdita/README.md
+++ b/packages/lwdita-xdita/README.md
@@ -20,23 +20,23 @@ yarn add @evolvedbinary/lwdita-xdita
 ```
 
 ```javascript
-const { xditaToJson } = require("@evolvedbinary/lwdita-xdita");
+const { xditaToJdita } = require("@evolvedbinary/lwdita-xdita");
 
 const xml = `
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
 <topic>...</topic>
 `
-xditaToJson(xml)
+xditaToJdita(xml)
   .then(JDitaDocument => console.log(JSON.stringify(result, null, 2)))
   .catch(error => console.log('Failed to convert:', error));
 ```
 
-By default, `xditaToJson` will fail when it encounters any error (XML syntax errors, validation errors,...).
+By default, `xditaToJdita` will fail when it encounters any error (XML syntax errors, validation errors,...).
 If you want to ignore any errors and work with whatever data the function could collect, set the second argument `abortOnError` to `false`:
 
 ```javascript
-xditaToJson(xml, false)
+xditaToJdita(xml, false)
 ```
 
 For more information, see [https://github.com/evolvedbinary/jdita](https://github.com/evolvedbinary/jdita).

--- a/packages/lwdita-xdita/classes.ts
+++ b/packages/lwdita-xdita/classes.ts
@@ -1,7 +1,7 @@
 import { SaxesAttributeNS } from "@rubensworks/saxes";
 
 /**
- * JDita is a JSON representation of a DITA XML document
+ * JDita is a Object representation of a DITA XML document
  */
 export interface JDita {
   nodeName: string;

--- a/packages/lwdita-xdita/converter.ts
+++ b/packages/lwdita-xdita/converter.ts
@@ -8,13 +8,13 @@ import { XditaSerializer } from "./xdita-serializer";
 /** TODO: Add tests for this module */
 
 /**
- * xditaToJdita - Converts XML to a JDita document tree
+ * Converts XML to an AST document tree
  *
  * @param xml - XML string
  * @param abortOnError - If true, abort on error
  * @returns - Promise of a DocumentNode
  */
-export async function xditaToJdita(xml: string, abortOnError = true): Promise<DocumentNode> {
+export async function xditaToAst(xml: string, abortOnError = true): Promise<DocumentNode> {
   return new Promise((resolve, reject) => {
     const errors: Error[] = [];
     // Create a Parser Object
@@ -97,14 +97,24 @@ export async function xditaToJdita(xml: string, abortOnError = true): Promise<Do
 }
 
 /**
- * xditaToJson - Convert the document tree to json
+ * Convert the document tree to JDita object
  *
  * @param xml - The XML input as string
  * @param abortOnError - Boolean, if true, stop execution and report errors
- * @returns The XML document tree object
+ * @returns JDita object
  */
-export async function xditaToJson(xml: string, abortOnError = true): Promise<JDita> {
-  return xditaToJdita(xml, abortOnError).then(doc => doc.json);
+export async function xditaToJdita(xml: string, abortOnError = true): Promise<JDita> {
+  return xditaToAst(xml, abortOnError).then(astToJdita);
+}
+
+/**
+ * Convert the document node to JDita object
+ * 
+ * @param document - DocumentNode
+ * @returns JDita object
+ */
+export function astToJdita(document: DocumentNode): JDita {
+  return document.json;
 }
 
 /**

--- a/packages/lwdita-xdita/example.ts
+++ b/packages/lwdita-xdita/example.ts
@@ -1,4 +1,4 @@
-import { xditaToJson, xditaToJdita, serializeToXML } from "./converter";
+import { xditaToJdita, xditaToAst, serializeToXML } from "./converter";
 import { BaseNode, TextNode, TopicNode } from "@evolvedbinary/lwdita-ast/nodes";
 import { storeOutputXML } from "./utils";
 import path from 'path';
@@ -37,7 +37,7 @@ const xml =
  * <topic><title>valid title</title><body><p>text</p></body></topic>
  * ```
  */
-xditaToJdita(xml)
+xditaToAst(xml)
   .then(jditaAst => {
     // Console log an object containing the AST:
     console.log(JSON.stringify(jditaAst.json, null, 2));

--- a/packages/lwdita-xdita/test/converter.spec.ts
+++ b/packages/lwdita-xdita/test/converter.spec.ts
@@ -1,11 +1,11 @@
 
 import { expect } from 'chai';
-import { serializeToXML, xditaToJdita, xditaToJson } from '../converter';
+import { serializeToXML, xditaToAst, xditaToJdita } from '../converter';
 
-describe('xditaToJdita', () => {
+describe('xditaToAst', () => {
   it('converts XDITA XML to JDITA DocumentNode', async () => {
     const xml = `<topic id="topicID"><title>text content</title></topic>`;
-    const jdita = await xditaToJdita(xml);
+    const jdita = await xditaToAst(xml);
 
     const topicNode = jdita.children[0];
 
@@ -32,7 +32,7 @@ describe('xditaToJdita', () => {
   it('rejects with errors if XML parsing fails', async () => {
     const xml = `<invalid-xml`;
 
-    expect(xditaToJdita(xml)).to.be.throw;
+    expect(xditaToAst(xml)).to.be.throw;
   });
 });
 
@@ -40,7 +40,7 @@ describe('jditaToXdita', () => {
   it('converts XDITA DocumentNode to JDITA json', async () => {
     const xdita = `<topic id="topicID"><title>text content</title></topic>`;
 
-    const xditaJson = await xditaToJson(xdita);
+    const xditaJson = await xditaToJdita(xdita);
     const json = {
       "nodeName": "document",
       "attributes": undefined,
@@ -88,7 +88,7 @@ describe('jditaToXdita', () => {
 describe('serializeToXML', () => {
   it('serializes the root node to XML', async () => {
     const xml = `<topic id="topicID"><title>text content</title></topic>`;
-    const jdita = await xditaToJdita(xml);
+    const jdita = await xditaToAst(xml);
 
     const result = serializeToXML(jdita);
 
@@ -98,7 +98,7 @@ describe('serializeToXML', () => {
 
   it('serializes the root node to XML with indentation', async () => {
     const xml = `<topic id="topicID"><title>text content</title></topic>`;
-    const jdita = await xditaToJdita(xml);
+    const jdita = await xditaToAst(xml);
 
     const result = serializeToXML(jdita, ' ', 2);
 


### PR DESCRIPTION
Rename `xditaToJson` to `xditaToJdita` and `xditaToJdita` to `xditaToAst`.
Also create a new function `astToJdita`. 
These changes should clarify the functions more.